### PR TITLE
Fix spelling and whitespace errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
   <h1 align="center">Starhub</h1>
   <h3 align="center">https://starhub.be/</h3>
   <h5 align="center">https://starhub.be/YOUR-GITHUB-LOGIN</h5>
-  <p align="center">All about your Github account, public and private activity, stars count, release download count, who followed/unfollowed and starred/unstarred your Github repositories plus daily email notification about changes and much more.</p>
+  <p align="center">All about your GitHub account, public and private activity, stars count, release download count, who followed/unfollowed and starred/unstarred your GitHub repositories plus daily email notification about changes and much more.</p>
 </p>
 
 ---

--- a/static/apps.html
+++ b/static/apps.html
@@ -1,6 +1,6 @@
 {{ define "title" }}
     <h4 class="what-is-it" style="font-weight: bold; margin-bottom: unset;">
-        Github Apps</br>
+        GitHub Apps</br>
         All related useful apps in one place  
     </h4>
 {{ end }}
@@ -16,22 +16,19 @@
 </h3>
 <div class="ui very padded segment">
     <p style="font-size:17px; margin-top:0;">
-    <b>Github Profile</b></p><p>
-    
+    <b>GitHub Profile</b></p><p>
+
     <a href="https://ghuser.io/" target="_blank"><b>Ghuser.io</b></a>
     <i style="padding-left:5px"></i>
     <i class="star blue small icon"></i>
     <i class="star blue small icon"></i>
     <i class="star blue small icon"></i>
     <i class="star grey small icon"></i></br>
-    An alternative Github profile</br>
-
-
-    
+    An alternative GitHub profile</br>
 
     </br></br><p style="font-size:17px; margin-top:0;">
     <b>Manage Notifications</b></p><p>
-    
+
     <a href="https://octobox.io/" target="_blank"><b>Octobox</b></a>
     <i style="padding-left:5px"></i>
     <i class="star blue small icon"></i>
@@ -40,43 +37,35 @@
     <i class="star grey small icon"></i></br>
     Manage,filter and order your GitHub Notification</br>
 
-
-
-    
     </br></br><p style="font-size:17px">
     <b>Starred Repos</b></p>
 
     <a href="https://app.astralapp.com" target="_blank"><b>Astral</b></a>
     <i style="padding-left:5px"></i>
-	<i class="star blue small icon"></i>
+    <i class="star blue small icon"></i>
     <i class="star blue small icon"></i>
     <i class="star blue small icon"></i>
     <i class="star blue small icon"></i></br>
-    Organize your Github starred repos with ease</br>
-    
+    Organize your GitHub starred repos with ease</br>
 
-
-
-	</br></br><p style="font-size:17px">
+    </br></br><p style="font-size:17px">
     <b>GitHub Traffic</b></p>
 
     <a href="https://github.com/igrigorik/ga-beacon" target="_blank"><b>Ga-Beacon</b></a>
     <i style="padding-left:5px"></i>
-	<i class="star blue small icon"></i>
+    <i class="star blue small icon"></i>
     <i class="star blue small icon"></i>
     <i class="star blue small icon"></i>
     <i class="star blue small icon"></i></br>
-    How to integrate Google Analytics to Github</br></br>
-
-
+    How to integrate Google Analytics to GitHub</br></br>
 
     <a href="https://madnight.github.io/githut" target="_blank"><b>Githut</b></a>
     <i style="padding-left:5px"></i>
-	<i class="star blue small icon"></i>
+    <i class="star blue small icon"></i>
     <i class="star blue small icon"></i>
     <i class="star blue small icon"></i>
     <i class="star blue small icon"></i></br>
-    Github main site language statistics</br>
+    GitHub main site language statistics</br>
 
 </div>
 
@@ -84,10 +73,10 @@
   Browser Addons
 </h3>
 <div class="ui very padded segment">
-	<p style="font-size:17px; margin-top:0;">
+    <p style="font-size:17px; margin-top:0;">
     <b>Firefox Addons</b></p>
 
-    <a href="https://github.com/freaktechnik/advanced-github-notifier" target="_blank"><b>Advanced-Github-Notifier</b></a>
+    <a href="https://github.com/freaktechnik/advanced-github-notifier" target="_blank"><b>advanced-github-notifier</b></a>
     <i style="padding-left:5px"></i>
     <i class="star blue small icon"></i>
     <i class="star blue small icon"></i>
@@ -95,17 +84,17 @@
     <i class="star blue small icon"></i></br>
     GitHub notifications</br></br>
 
-    <a href="https://github.com/pomber/git-history" target="_blank"><b>Git-History</b></a>
+    <a href="https://github.com/pomber/git-history" target="_blank"><b>git-history</b></a>
     <i style="padding-left:5px"></i>
-	<i class="star blue small icon"></i>
+    <i class="star blue small icon"></i>
     <i class="star blue small icon"></i>
     <i class="star blue small icon"></i>
     <i class="star blue small icon"></i></br>
     GitHub repo file history</br><br>
 
-    <a href="https://github.com/Mottie/GitHub-userscripts" target="_blank"><b>Github-Userscript</b></a>
+    <a href="https://github.com/Mottie/GitHub-userscripts" target="_blank"><b>GitHub-userscripts</b></a>
     <i style="padding-left:5px"></i>
-	<i class="star blue small icon"></i>
+    <i class="star blue small icon"></i>
     <i class="star blue small icon"></i>
     <i class="star blue small icon"></i>
     <i class="star half blue small icon"></i></br>
@@ -113,51 +102,48 @@
 
     <a href="https://github.algolia.com/" target="_blank"><b>Algolia</b></a>
     <i style="padding-left:5px"></i>
-	<i class="star blue small icon"></i>
+    <i class="star blue small icon"></i>
     <i class="star blue small icon"></i>
     <i class="star blue small icon"></i>
     <i class="star grey small icon"></i></br>
     Enhancing GitHub's search bar with autocomplete</br>
 
-
-
-
-	</br></br><p style="font-size:17px">
+    </br></br><p style="font-size:17px">
     <b>Chrome Extensions</b></p>
 
-    <a href="https://chrome.google.com/webstore/detail/notifier-for-github/lmjdlojahmbbcodnpecnjnmlddbkjhnn" target="_blank"><b>Notifier-For-Github</b></a>
+    <a href="https://chrome.google.com/webstore/detail/notifier-for-github/lmjdlojahmbbcodnpecnjnmlddbkjhnn" target="_blank"><b>Notifier-For-GitHub</b></a>
     <i style="padding-left:5px"></i>
-	<i class="star blue small icon"></i>
+    <i class="star blue small icon"></i>
     <i class="star blue small icon"></i>
     <i class="star blue small icon"></i>
     <i class="star grey small icon"></i></br>
     GitHub notifications</br></br>
 
-    <a href="https://github.com/muan/github-dashboard" target="_blank"><b>Github-Dashboard-Filter</b></a>
+    <a href="https://github.com/muan/github-dashboard" target="_blank"><b>GitHub-Dashboard-Filter</b></a>
     <i style="padding-left:5px"></i>
-	<i class="star blue small icon"></i>
+    <i class="star blue small icon"></i>
     <i class="star blue small icon"></i>
     <i class="star blue small icon"></i>
     <i class="star blue small icon"></i></br>
     Filter GitHub dashboard elements</br></br>
 
-    <a href="https://github.com/tanmayrajani/notifications-preview-github" target="_blank"><b>Notifications-Preview-Githubb</b></a>
+    <a href="https://github.com/tanmayrajani/notifications-preview-github" target="_blank"><b>notifications-preview-github</b></a>
     <i style="padding-left:5px"></i>
-	<i class="star blue small icon"></i>
+    <i class="star blue small icon"></i>
     <i class="star blue small icon"></i>
     <i class="star blue small icon"></i>
     <i class="star grey small icon"></i></br>
     GitHub notifications preview and count</br></br>
     
-    <a href="https://github.com/onlylemi/github-downloader" target="_blank"><b>Github-Downloader</b></a>
-	<i style="padding-left:5px"></i>
-	<i class="star blue small icon"></i>
+    <a href="https://github.com/onlylemi/github-downloader" target="_blank"><b>github-downloader</b></a>
+    <i style="padding-left:5px"></i>
+    <i class="star blue small icon"></i>
     <i class="star blue small icon"></i>
     <i class="star blue small icon"></i>
     <i class="star blue small icon"></i></br>
     GitHub download icons</br></br>
 
-    <a href="https://github.com/pomber/git-history" target="_blank"><b>Git-History</b></a>
+    <a href="https://github.com/pomber/git-history" target="_blank"><b>git-history</b></a>
     <i style="padding-left:5px"></i>
 	<i class="star blue small icon"></i>
     <i class="star blue small icon"></i>
@@ -165,9 +151,9 @@
     <i class="star blue small icon"></i></br>
     GitHub repo file history</br></br>
 
-    <a href="https://github.com/Mottie/GitHub-userscripts" target="_blank"><b>Github-Userscript</b></a>
+    <a href="https://github.com/Mottie/GitHub-userscripts" target="_blank"><b>GitHub-userscripts</b></a>
     <i style="padding-left:5px"></i>
-	<i class="star blue small icon"></i>
+    <i class="star blue small icon"></i>
     <i class="star blue small icon"></i>
     <i class="star blue small icon"></i>
     <i class="star half blue small icon"></i></br>
@@ -175,7 +161,7 @@
 
     <a href="https://github.algolia.com/" target="_blank"><b>Algolia</b></a>
     <i style="padding-left:5px"></i>
-	<i class="star blue small icon"></i>
+    <i class="star blue small icon"></i>
     <i class="star blue small icon"></i>
     <i class="star blue small icon"></i>
     <i class="star grey small icon"></i></br>
@@ -185,25 +171,25 @@
 </div>
 
 <div class="ui very padded segment">
-	<script src="static/resources/images/ads.js"></script>
-	<script>
+    <script src="static/resources/images/ads.js"></script>
+    <script>
         if( window.canRunAds === undefined ){
         // adblocker detected, show fallback
         document.write('<div align="center" style="background-image: url(static/resources/images/image.png);');
         document.write('background-repeat:no-repeat; background-position:center;height:60px;"></div>');}
-	</script>
-	<div align="center">
+    </script>
+    <div align="center">
         <script type="text/javascript">
-	        google_ad_client = "ca-pub-4643883406855060";
-	        google_ad_slot = "6799285178";
-	        google_ad_width = 468;
-	        google_ad_height = 60;
+            google_ad_client = "ca-pub-4643883406855060";
+            google_ad_slot = "6799285178";
+            google_ad_width = 468;
+            google_ad_height = 60;
         </script>
         <!-- Starhub main -->
         <script type="text/javascript"
         	src="//pagead2.googlesyndication.com/pagead/show_ads.js">
         </script>
-	</div>
+    </div>
 </div>
 
 <h3 id="privacy" class="ui header">
@@ -211,80 +197,68 @@
 </h3>
 <div class="ui very padded segment">
 
-	<p style="font-size:17px; margin-top:0;">
+    <p style="font-size:17px; margin-top:0;">
     <b>Changes Reports</b></p>
-    
+
     <a href="https://github.com/apps/weekly-digest/" target="_blank"><b>Weekly-Digest</b></a>
     <i style="padding-left:5px"></i>
-	<i class="star blue small icon"></i>
+    <i class="star blue small icon"></i>
     <i class="star blue small icon"></i>
     <i class="star blue small icon"></i>
     <i class="star grey small icon"></i></br>
     GitHub weekly report over issue auto creation</br>
 
-
-
-
    	</br></br><p style="font-size:17px">
-    <b>Github CDN</b></p>
+    <b>GitHub CDN</b></p>
 
     <a href="https://www.jsdelivr.com/" target="_blank"><b>Jsdelivr</b></a>
     <i style="padding-left:5px"></i>
-	<i class="star blue small icon"></i>
+    <i class="star blue small icon"></i>
     <i class="star blue small icon"></i>
     <i class="star blue small icon"></i>
     <i class="star blue small icon"></i></br>
-    Delivering raw files from Github (CDN)</br>
+    Delivering raw files from GitHub (CDN)</br>
 
-
-    
-
-	</br></br><p style="font-size:17px">
+    </br></br><p style="font-size:17px">
     <b>GitHub Archive</b></p>
-    
+
     <a href="http://gharchive.org/" target="_blank"><b>Gharchive.org</b></a>
     <i style="padding-left:5px"></i>
-	<i class="star blue small icon"></i>
+    <i class="star blue small icon"></i>
     <i class="star blue small icon"></i>
     <i class="star blue small icon"></i>
     <i class="star grey small icon"></i></br>
     GitHub archive of public statistics</br>
 
-
-
-
-	</br></br><p style="font-size:17px">
+    </br></br><p style="font-size:17px">
     <b>GitHub Raw</b></p>
     
     <a href="https://raw.githack.com/" target="_blank"><b>Raw-Githack</b></a>
     <i style="padding-left:5px"></i>
-	<i class="star blue small icon"></i>
+    <i class="star blue small icon"></i>
     <i class="star blue small icon"></i>
     <i class="star blue small icon"></i>
     <i class="star grey small icon"></i></br>
     Get raw files from various repos</br>
 
-    
-
-
     </br></br><p style="font-size:17px;">
-    <b>Github Profile</b></p><p>
+    <b>GitHub Profile</b></p><p>
 
-    <a href="https://gp.fedepot.com" target="_blank"><b>Fedepot Github-Profile</b></a>
+    <a href="https://gp.fedepot.com" target="_blank"><b>Fedepot GitHub-Profile</b></a>
     <i style="padding-left:5px"></i>
 	<i class="star blue small icon"></i>
     <i class="star blue small icon"></i>
     <i class="star grey small icon"></i>
     <i class="star grey small icon"></i></br>
-    Github alternative profile (does not handle organizations and thus not accurate)</br></br>
+    GitHub alternative profile (does not handle organizations and thus not accurate)</br></br>
 
-    <a href="https://profile-summary-for-github.com/" target="_blank"><b>Tipsy Profile-Summary-For-Github</b></a>
+    <a href="https://profile-summary-for-github.com/" target="_blank"><b>Tipsy Profile-Summary-For-GitHub</b></a>
     <i style="padding-left:5px"></i>
 	<i class="star blue small icon"></i>
     <i class="star blue small icon"></i>
     <i class="star grey small icon"></i>
     <i class="star grey small icon"></i></br>
-    Github alternative profile (does not handle organizations and thus not accurate)</br></br>
+    GitHub alternative profile (does not handle organizations and thus not accurate)</br></br>
       
     <a href="http://git-awards.com" target="_blank"><b>Git-Awards.com</b></a>
     <i style="padding-left:5px"></i>
@@ -296,62 +270,55 @@
 
     <a href="https://gitmemory.com" target="_blank"><b>Gitmemory.com</b></a>
     <i style="padding-left:5px"></i>
-	<i class="star blue small icon"></i>
+    <i class="star blue small icon"></i>
     <i class="star blue small icon"></i>
     <i class="star grey small icon"></i>
     <i class="star grey small icon"></i></br>
-    Github alternative profile (not accurate)</br>
+    GitHub alternative profile (not accurate)</br>
 
 
-    
-
-	</br></br><p style="font-size:17px">
+    </br></br><p style="font-size:17px">
     <b>GitHub Activity</b></p>
-    
-    <a href="https://razat249.github.io/github-view/" target="_blank"><b>Github-View</b></a>
+
+    <a href="https://razat249.github.io/github-view/" target="_blank"><b>github-view</b></a>
     <i style="padding-left:5px"></i>
-	<i class="star blue small icon"></i>
+    <i class="star blue small icon"></i>
     <i class="star blue small icon"></i>
     <i class="star blue small icon"></i>
     <i class="star grey small icon"></i></br>
     GitHub repo and profile public activity (does not handle all events, and does not show icons)</br></br>
 
-    <a href="https://github.com/smuyyh/GitHubWidgets/" target="_blank"><b>Github-Widgets</b></a>
+    <a href="https://github.com/smuyyh/GitHubWidgets/" target="_blank"><b>GitHubWidgets</b></a>
     <i style="padding-left:5px"></i>
-	<i class="star blue small icon"></i>
+    <i class="star blue small icon"></i>
     <i class="star blue small icon"></i>
     <i class="star blue small icon"></i>
     <i class="star grey small icon"></i></br>
     GitHub repo and profile javascript widgets</br></br>
 
-    <a href="http://ionicabizau.github.io/github-profile-languages/" target="_blank"><b>Github-Profile-Languages</b></a>
+    <a href="http://ionicabizau.github.io/github-profile-languages/" target="_blank"><b>github-profile-languages</b></a>
     <i style="padding-left:5px"></i>
-	<i class="star blue small icon"></i>
+    <i class="star blue small icon"></i>
     <i class="star blue small icon"></i>
     <i class="star grey small icon"></i>
     <i class="star grey small icon"></i></br>
     GitHub repo and profile programming languages pie chart (not accurate and does not handle organizations)</br>
 
-
-
-	</br></br><p style="font-size:17px">
+    </br></br><p style="font-size:17px">
     <b>GitHub Traffic</b></p>
     
-    <a href="https://github-traffic-viewer.netlify.com/" target="_blank"><b>Github-Traffic</b></a>
+    <a href="https://github-traffic-viewer.netlify.com/" target="_blank"><b>GitHub-Traffic</b></a>
     <i style="padding-left:5px"></i>
-	<i class="star blue small icon"></i>
+    <i class="star blue small icon"></i>
     <i class="star blue small icon"></i>
     <i class="star grey small icon"></i>
     <i class="star grey small icon"></i></br>
     GitHub repo traffic (does not show referrers)</br>
 
-
-
-
    	</br></br><p style="font-size:17px">
     <b>Stars History</b></p>
 
-    <a href="https://stars.przemeknowak.com/" target="_blank"><b>Github-Stars-History</b></a>
+    <a href="https://stars.przemeknowak.com/" target="_blank"><b>GitHub-Stars-History</b></a>
     <i style="padding-left:5px"></i>
 	<i class="star blue small icon"></i>
     <i class="star blue small icon"></i>
@@ -378,7 +345,7 @@
 	Alternative stars history engine, compare stars history for multiple repos</br>
     Can be done on the <a href="/startrack">stars stats</a> section</br></br>
 
-    <a href="https://pingao777.github.io/github-gazer/?q=pingao777/markdown-preview-sync" target="_blank"><b>Github-Gazer</b></a>
+    <a href="https://pingao777.github.io/github-gazer/?q=pingao777/markdown-preview-sync" target="_blank"><b>GitHub-Gazer</b></a>
     <i style="padding-left:5px"></i>
 	<i class="star blue small icon"></i>
     <i class="star blue small icon"></i>

--- a/static/contact.html
+++ b/static/contact.html
@@ -1,6 +1,6 @@
 {{ define "title" }}
 	<h4 class="what-is-it" style="font-weight: bold; margin-bottom: unset;">
-		All about your Github account, public and private activity, stars, followers and much more
+		All about your GitHub account, public and private activity, stars, followers and much more
 	</h4>
 {{ end }}
 {{ define "content-naked" }}
@@ -15,7 +15,7 @@
 </h3>
 <div class="ui very padded segment">
   <p>
-	Starhub, is an open source project based on many other applications, it is meant to be a central location for Github's users that wants to get some extra features about their accounts, being a community project any contribution is more than welcome</br></br> 
+	Starhub, is an open source project based on many other applications, it is meant to be a central location for GitHub's users that wants to get some extra features about their accounts, being a community project any contribution is more than welcome</br></br> 
 	This application is developed by: </br></br>
 	<i class="github icon"></i><a class="ui" href="https://github.com/intika" target="_blank">intika@github</a></br> 
 	<i class="github icon"></i><a href="https://starhub.be/">https://starhub.be/</a></br>
@@ -48,16 +48,16 @@
 	- HTML-Preview by <a class="ui" href="https://github.com/niutech" target="_blank">@niutech</a></br>
 	- Profile-Summary by <a class="ui" href="https://github.com/tipsy" target="_blank">@tipsy</a></br>
 	- Down-Git by <a class="ui" href="https://github.com/MinhasKamal" target="_blank">@MinhasKamal</a></br>
-	- Github-ID by <a class="ui" href="https://github.com/caius" target="_blank">@caius</a></br>
-	- Github-ID by <a class="ui" href="https://github.com/pingao777" target="_blank">@pingao777</a></br>
-	- Github-Corners by <a class="ui" href="https://github.com/tholman" target="_blank">@tholman</a></br>
-	- Github-Gazer by <a class="ui" href="https://github.com/pingao777" target="_blank">@pingao777</a></br>
-	- Github-Stats by <a class="ui" href="https://github.com/byliuyang" target="_blank">@byliuyang</a></br>
-	- Github-Profile by <a class="ui" href="https://github.com/thundernet8" target="_blank">@thundernet8</a></br>
-	- Github-View by <a class="ui" href="https://github.com/razat249" target="_blank">@razat249</a></br>
-	- Github-Widget by <a class="ui" href="https://github.com/smuyyh" target="_blank">@smuyyh</a></br>
-	- Github-Release-Stats by <a class="ui" href="https://github.com/Somsubhra" target="_blank">@Somsubhra</a></br>
-	- Github-Activity by <a class="ui" href="https://github.com/caseyscarborough" target="_blank">@caseyscarborough</a></br>
+	- GitHub-ID by <a class="ui" href="https://github.com/caius" target="_blank">@caius</a></br>
+	- GitHub-ID by <a class="ui" href="https://github.com/pingao777" target="_blank">@pingao777</a></br>
+	- GitHub-Corners by <a class="ui" href="https://github.com/tholman" target="_blank">@tholman</a></br>
+	- GitHub-Gazer by <a class="ui" href="https://github.com/pingao777" target="_blank">@pingao777</a></br>
+	- GitHub-Stats by <a class="ui" href="https://github.com/byliuyang" target="_blank">@byliuyang</a></br>
+	- GitHub-Profile by <a class="ui" href="https://github.com/thundernet8" target="_blank">@thundernet8</a></br>
+	- GitHub-View by <a class="ui" href="https://github.com/razat249" target="_blank">@razat249</a></br>
+	- GitHub-Widget by <a class="ui" href="https://github.com/smuyyh" target="_blank">@smuyyh</a></br>
+	- GitHub-Release-Stats by <a class="ui" href="https://github.com/Somsubhra" target="_blank">@Somsubhra</a></br>
+	- GitHub-Activity by <a class="ui" href="https://github.com/caseyscarborough" target="_blank">@caseyscarborough</a></br>
 	- A stackoverflow <a class="ui" href="https://stackoverflow.com/questions/12686545/how-to-leave-a-message-for-a-github-com-user" target="_blank">question</a></br>
 	</p>
 </div>
@@ -85,7 +85,7 @@
 		<p><strong>Tunnel With Ngrok</strong></p>
 		<p>To test the entire flow, you’ll need to install ngrok, after the installation run:</p>
 		<i>ngrok http 3000</i></br></br>
-		<p><strong>Register With Github</strong></p>
+		<p><strong>Register With GitHub</strong></p>
 		<p>On <a href="https://github.com/settings/applications/new">github</a>, fill the form with the following informations:</p>
 		<ol>
 			<li>Application name: starhub-dev-username</li>
@@ -107,7 +107,7 @@
 <div class="ui very padded segment">
   <p>
     <b>We use cookies and datas collection to ensure that you have the best experience on our website.</b></br>
-    <b>None of the collected datas from Github are disclosed to third party.</b>
+    <b>None of the collected datas from GitHub are disclosed to third party.</b>
     
 	</br></br><b>
     Cookies are used to:</br></b></br>
@@ -119,7 +119,7 @@
     </br><b>
     This website collect datas to:</br></b></br>
     
-    - Deliver its main service (notifications about Github activity)</br>
+    - Deliver its main service (notifications about GitHub activity)</br>
     - Know its audience to deliver a better service</br>
     - Display advertisement by third party</br>
     

--- a/static/donate.html
+++ b/static/donate.html
@@ -1,6 +1,6 @@
 {{ define "title" }}
     <h4 class="what-is-it" style="font-weight: bold; margin-bottom: unset;">
-		All about your Github account, public and private activity, stars, followers and much more
+		All about your GitHub account, public and private activity, stars, followers and much more
     </h4>
 {{ end }}
 {{ define "content-naked" }}

--- a/static/downloads.html
+++ b/static/downloads.html
@@ -1,7 +1,7 @@
 {{ define "title" }}
     <h4 class="what-is-it" style="font-weight: bold; margin-bottom: unset;">
         Downloads Statistics</br>
-        Get stats like download counts, release dates, authors for any Github project
+        Get stats like download counts, release dates, authors for any GitHub project
     </h4>
 {{ end }}
 {{ define "content" }}
@@ -17,8 +17,8 @@
 	<script type="text/javascript" src="static/resources/downloads/js/main.js"></script>
 
 	<meta name="viewport" content="width=device-width, initial-scale=1">
-	<meta name="description" content="Get the latest release stats like download counts, release dates, author on any Github project">
-	<meta name="keywords" content="Github, release, download, count">
+	<meta name="description" content="Get the latest release stats like download counts, release dates, author on any GitHub project">
+	<meta name="keywords" content="github, release, download, count">
 	<link href="https://fonts.googleapis.com/css?family=Roboto|Roboto+Mono" rel="stylesheet" type="text/css">
 	<link rel="stylesheet" href="static/resources/downloads/third-party/bootstrap/css/bootstrap.min.css">
 	<link rel="stylesheet" href="static/resources/downloads/css/main.css">
@@ -31,7 +31,7 @@
         <div class="col-md-4 col-md-offset-4">
             <div class="form form-inline">
                 <div class="form-group">
-                    <input type="text" class="form-control" id="username" placeholder="Github username">
+                    <input type="text" class="form-control" id="username" placeholder="GitHub username">
                 </div>
                 <div class="form-group">
                     <input type="text" class="form-control" id="repository" placeholder="Repository name">

--- a/static/index.html
+++ b/static/index.html
@@ -1,6 +1,6 @@
 {{ define "title" }}
     <h4 class="what-is-it" style="font-weight: bold; margin-bottom: unset;">
-        All about your Github account, public and private activity, stars, followers and much more
+        All about your GitHub account, public and private activity, stars, followers and much more
     </h4>
 {{ end }}
 
@@ -21,8 +21,8 @@
 	<div class="ui very padded segment">
 		<h3 class="ui header">Starhub:</h3>
 		<p>
-		All about your Github account, public and private activity, stars count, release download count, 
-		who followed/unfollowed and starred/unstarred your Github repositories plus daily email notification about changes and much more.</br>
+		All about your GitHub account, public and private activity, stars count, release download count, 
+		who followed/unfollowed and starred/unstarred your GitHub repositories plus daily email notification about changes and much more.</br>
 
 		<h3 class="ui header">Features:</h3>
 	
@@ -198,7 +198,7 @@
 			Check now
 			</a>
 			<a class="ui blue small button"		   style="margin:1%; width:31%;" href="https://github.com/settings/connections/applications/{{ .ClientID }}" target="_blank"
-			title="Change starhub settings on Github">
+			title="Change starhub settings on GitHub">
 			<i class="cogs black icon" height="16" width="16" style="margin-right:5px"></i>
 			Change settings
 			</a>
@@ -616,12 +616,12 @@
 		</div>
 
 		<div class="ui padded segment">
-				<p style="text-align:center; font-size:17px;"><b>Github Tools Bookmarks</b></p>
+				<p style="text-align:center; font-size:17px;"><b>GitHub Tools Bookmarks</b></p>
 
-				<a class="ui primary small button" target="_blank" title="Github.com dashboard (open in new tab)" style="margin:1%; width:98%;" href="https://github.com/" >
+				<a class="ui primary small button" target="_blank" title="GitHub.com dashboard (open in new tab)" style="margin:1%; width:98%;" href="https://github.com/" >
 					<img src="" height="16" width="0" style="vertical-align:middle; margin-right:0px;">
 					<i class="github black icon" height="16" width="16" style="margin-right:5px"></i>
-					Github dashboard
+					GitHub dashboard
 				</a>
 
 				<a class="ui primary small button" target="_blank" title="Ghuser.io (open in new tab)" style="margin:1%; width:31%;" href="https://ghuser.io/{{ .User.Login}}" >

--- a/static/layout.html
+++ b/static/layout.html
@@ -56,13 +56,13 @@
 			Toolbox
 			<i class="dropdown icon"></i>
 			<div class="ui inverted grey menu" style="margin:0px;">
-				<a class="item" href="/profile" 					title="Starhub github's profile summary for any user">Github Profiler</a>
-				<a class="item" href="/apps"					    title="Github apps listing">Github Applications</a>
-				<a class="item" href="/tools#mail-finder"           title="Find any user email">Github eMail Finder</a>
-				<a class="item" href="/tools#site-preview"          title="Preview HTML files">Github Site Preview</a>
-				<a class="item" href="/tools#userid-converter"      title="Convert user-id to username">Github User-ID Converter</a>
-				<a class="item" href="/tools#folder-downloader" 	title="Download any folder from a repo">Github Folder Downloader</a>
-				<a class="item" href="/tools#username-converter"    title="Convert username to user-id">Github Username Converter</a>
+				<a class="item" href="/profile" 					title="Starhub github's profile summary for any user">GitHub Profiler</a>
+				<a class="item" href="/apps"					    title="GitHub apps listing">GitHub Applications</a>
+				<a class="item" href="/tools#mail-finder"           title="Find any user email">GitHub eMail Finder</a>
+				<a class="item" href="/tools#site-preview"          title="Preview HTML files">GitHub Site Preview</a>
+				<a class="item" href="/tools#userid-converter"      title="Convert user-id to username">GitHub User-ID Converter</a>
+				<a class="item" href="/tools#folder-downloader" 	title="Download any folder from a repo">GitHub Folder Downloader</a>
+				<a class="item" href="/tools#username-converter"    title="Convert username to user-id">GitHub Username Converter</a>
 			</div>
 		</div>
 
@@ -71,7 +71,7 @@
 
 		{{ if eq .User.ID 0 }}
 		
-		<a class="green active item" style="margin-left: 75px; border-radius: 5px;" href="/login" title="Authenticate with Github">
+		<a class="green active item" style="margin-left: 75px; border-radius: 5px;" href="/login" title="Authenticate with GitHub">
 		<i class="github icon"></i>
 		Login</a>
 
@@ -86,7 +86,7 @@
       </div>
     </div>
   
-	<a href="https://github.com/Github-Web-Apps/Starhub" class="github-corner" target="_blank" title="Star/Fork/Watch me on Github" aria-label="View source on GitHub"><svg width="80" height="80" viewBox="0 0 250 250" style="fill:#70B7FD; color:#fff; position: absolute; top: 0; border: 0; right: 0;" aria-hidden="true"><path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z"></path><path d="M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7 120.5,78.6 120.5,78.6 C119.2,72.0 123.4,76.3 123.4,76.3 C127.3,80.9 125.5,87.3 125.5,87.3 C122.9,97.6 130.6,101.9 134.4,103.2" fill="currentColor" style="transform-origin: 130px 106px;" class="octo-arm"></path><path d="M115.0,115.0 C114.9,115.1 118.7,116.5 119.8,115.4 L133.7,101.6 C136.9,99.2 139.9,98.4 142.2,98.6 C133.8,88.0 127.5,74.4 143.8,58.0 C148.5,53.4 154.0,51.2 159.7,51.0 C160.3,49.4 163.2,43.6 171.4,40.1 C171.4,40.1 176.1,42.5 178.8,56.2 C183.1,58.6 187.2,61.8 190.9,65.4 C194.5,69.0 197.7,73.2 200.1,77.6 C213.8,80.2 216.3,84.9 216.3,84.9 C212.7,93.1 206.9,96.0 205.4,96.6 C205.1,102.4 203.0,107.8 198.3,112.5 C181.9,128.9 168.3,122.5 157.7,114.1 C157.9,116.9 156.7,120.9 152.7,124.9 L141.0,136.5 C139.8,137.7 141.6,141.9 141.8,141.8 Z" fill="currentColor" class="octo-body"></path></svg></a><style>.github-corner:hover .octo-arm{animation:octocat-wave 560ms ease-in-out}@keyframes octocat-wave{0%,100%{transform:rotate(0)}20%,60%{transform:rotate(-25deg)}40%,80%{transform:rotate(10deg)}}@media (max-width:500px){.github-corner:hover .octo-arm{animation:none}.github-corner .octo-arm{animation:octocat-wave 560ms ease-in-out}}</style>
+	<a href="https://github.com/Github-Web-Apps/Starhub" class="github-corner" target="_blank" title="Star/Fork/Watch me on GitHub" aria-label="View source on GitHub"><svg width="80" height="80" viewBox="0 0 250 250" style="fill:#70B7FD; color:#fff; position: absolute; top: 0; border: 0; right: 0;" aria-hidden="true"><path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z"></path><path d="M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7 120.5,78.6 120.5,78.6 C119.2,72.0 123.4,76.3 123.4,76.3 C127.3,80.9 125.5,87.3 125.5,87.3 C122.9,97.6 130.6,101.9 134.4,103.2" fill="currentColor" style="transform-origin: 130px 106px;" class="octo-arm"></path><path d="M115.0,115.0 C114.9,115.1 118.7,116.5 119.8,115.4 L133.7,101.6 C136.9,99.2 139.9,98.4 142.2,98.6 C133.8,88.0 127.5,74.4 143.8,58.0 C148.5,53.4 154.0,51.2 159.7,51.0 C160.3,49.4 163.2,43.6 171.4,40.1 C171.4,40.1 176.1,42.5 178.8,56.2 C183.1,58.6 187.2,61.8 190.9,65.4 C194.5,69.0 197.7,73.2 200.1,77.6 C213.8,80.2 216.3,84.9 216.3,84.9 C212.7,93.1 206.9,96.0 205.4,96.6 C205.1,102.4 203.0,107.8 198.3,112.5 C181.9,128.9 168.3,122.5 157.7,114.1 C157.9,116.9 156.7,120.9 152.7,124.9 L141.0,136.5 C139.8,137.7 141.6,141.9 141.8,141.8 Z" fill="currentColor" class="octo-body"></path></svg></a><style>.github-corner:hover .octo-arm{animation:octocat-wave 560ms ease-in-out}@keyframes octocat-wave{0%,100%{transform:rotate(0)}20%,60%{transform:rotate(-25deg)}40%,80%{transform:rotate(10deg)}}@media (max-width:500px){.github-corner:hover .octo-arm{animation:none}.github-corner .octo-arm{animation:octocat-wave 560ms ease-in-out}}</style>
 
 	<div class="ui text container very padded">
 	  <h1 class="ui inverted header" style="margin-top:15px;"> 

--- a/static/profile.html
+++ b/static/profile.html
@@ -1,6 +1,6 @@
 {{ define "title" }}
     <h4 class="what-is-it" style="font-weight: bold; margin-bottom: unset;">
-		All about any Github account, public and private activity, stars, followers and much more
+		All about any GitHub account, public and private activity, stars, followers and much more
     </h4>
 {{ end }}
 {{ define "content-naked" }}
@@ -21,7 +21,7 @@
 	<div class="form form-inline" style="margin-right:100px; margin-left:100px;">
 		<p>Profile any github user (direct access with <b>https://starhub.be/username</b>)</p>
 		<div class="form-group">
-			<input type="text" class="form-control" id="username" placeholder="Github username (e.g. intika)" onkeydown = "if (event.keyCode == 13) document.getElementById('get-infos-1').click()">
+			<input type="text" class="form-control" id="username" placeholder="GitHub username (e.g. intika)" onkeydown = "if (event.keyCode == 13) document.getElementById('get-infos-1').click()">
 		</div>
 		
 		</br>
@@ -371,7 +371,7 @@
 </div>
 
 <div id="div6" class="ui padded segment" style="visibility:hidden; height:0px; padding:0px; margin:0px;">
-		<p style="text-align:center; font-size:17px;"><b>Github Profile Center</b></p>
+		<p style="text-align:center; font-size:17px;"><b>GitHub Profile Center</b></p>
 
 		<a class="ui primary small button" target="_blank" title="Ghuser.io (open in new tab)" style="margin:1%; width:31%;" id="ghuserLink" href="https://ghuser.io/" >
 			<img src="static/logo/3rd/ghu.png" height="16" width="16" style="vertical-align:middle; margin-right:5px;">

--- a/static/resources/github-id/_config.yml
+++ b/static/resources/github-id/_config.yml
@@ -1,4 +1,4 @@
 theme: jekyll-theme-hacker
-title: Starhub Github ID
+title: Starhub GitHub ID
 description: An overview of your github profile
 google_analytics:

--- a/static/resources/github-id/classic/_config.yml
+++ b/static/resources/github-id/classic/_config.yml
@@ -1,4 +1,4 @@
 theme: jekyll-theme-hacker
-title: Starhub Github ID
+title: Starhub GitHub ID
 description: An overview of your github profile
 google_analytics:

--- a/static/resources/github-id/classic/index.html
+++ b/static/resources/github-id/classic/index.html
@@ -6,9 +6,9 @@
     <meta name='viewport' content='width=device-width, initial-scale=1'>
     <link rel='stylesheet' href='style.css'>
     <!-- Begin Jekyll SEO tag v2.5.0 -->
-    <title>Starhub Github-ID</title>
+    <title>Starhub GitHub-ID</title>
     <meta name='generator' content='Jekyll v3.7.3.1'/>
-    <meta property='og:title' content='Starhub Github-ID'/>
+    <meta property='og:title' content='Starhub GitHub-ID'/>
     <meta property='og:locale' content='en_US'/>
     <meta property='og:site_name' content='github-id'/>
     <script type='text/javascript' src='https://cdnjs.cloudflare.com/ajax/libs/jquery/3.3.1/jquery.min.js'></script>

--- a/static/resources/github-id/index.html
+++ b/static/resources/github-id/index.html
@@ -6,9 +6,9 @@
     <meta name='viewport' content='width=device-width, initial-scale=1'>
     <link rel='stylesheet' href='style.css'>
     <!-- Begin Jekyll SEO tag v2.5.0 -->
-    <title>Starhub Github-ID</title>
+    <title>Starhub GitHub-ID</title>
     <meta name='generator' content='Jekyll v3.7.3.1'/>
-    <meta property='og:title' content='Starhub Github-ID'/>
+    <meta property='og:title' content='Starhub GitHub-ID'/>
     <meta property='og:locale' content='en_US'/>
     <meta property='og:site_name' content='github-id'/>
     <script type='text/javascript' src='https://cdnjs.cloudflare.com/ajax/libs/jquery/3.3.1/jquery.min.js'></script>

--- a/static/starred.html
+++ b/static/starred.html
@@ -1,6 +1,6 @@
 {{ define "title" }}
 	<h4 class="what-is-it" style="font-weight: bold; margin-bottom: unset;">
-		All about your Github account, public and private activity, stars, followers and much more
+		All about your GitHub account, public and private activity, stars, followers and much more
 	</h4>
 {{ end }}
 {{ define "content-naked" }}

--- a/static/tools.html
+++ b/static/tools.html
@@ -1,7 +1,7 @@
 {{ define "title" }}
     <h4 class="what-is-it" style="font-weight: bold; margin-bottom: unset;">
-        Github Tools</br>
-        Get email, user-id and username informations, plus folder downloader and site preview
+        GitHub Tools</br>
+        Get email, user-id and username information, plus folder downloader and site preview
     </h4>
 {{ end }}
 {{ define "content-naked" }}
@@ -16,15 +16,15 @@
 <script type="text/javascript" src="static/resources/html-preview/htmlpreview.js"></script>
 
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<meta name="description" content="Get the latest release stats like download counts, release dates, author on any Github project">
-<meta name="keywords" content="Github, release, download, count">
+<meta name="description" content="Get the latest release stats like download counts, release dates, author on any GitHub project">
+<meta name="keywords" content="github, release, download, count">
 
 <link href="https://fonts.googleapis.com/css?family=Roboto|Roboto+Mono" rel="stylesheet" type="text/css">
 <link rel="stylesheet" href="static/resources/downloads/third-party/bootstrap/css/bootstrap.min.css">
 <link rel="stylesheet" href="static/resources/downloads/css/main.css">
 
 <script>
- 	//$("h4.what-is-it").text("Get email, user-id, username informations for any Github user");
+ 	//$("h4.what-is-it").text("Get email, user-id, username information for any GitHub user");
 </script>
 
 <script type="text/javascript" charset="utf-8">
@@ -83,13 +83,13 @@
 <div class="ui text container">
 
 <h3 class="ui header" id="mail-finder">
-	Github user mail finder 
+	GitHub user mail finder
 </h3>
 <div class="ui very padded segment">
 	<p>Search and extract the email address from commits</p>
 		<div class="form form-inline">
 			<div class="form-group">
-				<input type="text" class="form-control" id="username" placeholder="Github username or repository link" onkeydown = "if (event.keyCode == 13) document.getElementById('get-infos-1').click()">
+				<input type="text" class="form-control" id="username" placeholder="GitHub username or repository link" onkeydown = "if (event.keyCode == 13) document.getElementById('get-infos-1').click()">
 			</div>
 
 			</br></br>
@@ -107,7 +107,7 @@
 
 
 <h3 class="ui header" id="folder-downloader">
-	Github folder downloader
+	GitHub folder downloader
 </h3>
 <div class="ui very padded segment">
 	<p>Direct download any folder from a git repo in a compressed zip file
@@ -137,7 +137,7 @@
 
 
 <h3 class="ui header" id="site-preview">
-  	Github site preview
+  	GitHub site preview
 </h3>
 <div class="ui very padded segment">
 	<p>Preview HTML file from any git repo (or prepend to the URL: <code>https://starhub.be/tools?</code> like this
@@ -168,13 +168,13 @@
 
 
 <h3 class="ui header" id="username-converter">
-  	Github username converter
+  	GitHub username converter
 </h3>
 <div class="ui very padded segment">
 	<p>Search and extract the user-id from the username</p>
 		<div class="form form-inline">
 			<div class="form-group">
-				<input type="text" class="form-control" id="username2" placeholder="Github username" onkeydown = "if (event.keyCode == 13) document.getElementById('get-infos-2').click()">
+				<input type="text" class="form-control" id="username2" placeholder="GitHub username" onkeydown = "if (event.keyCode == 13) document.getElementById('get-infos-2').click()">
 			</div>
 
 			</br></br>
@@ -192,13 +192,13 @@
 
 
 <h3 class="ui header" id="userid-converter">
-  	Github user-id converter
+  	GitHub user-id converter
 </h3>
 <div class="ui very padded segment">
 	<p>Search and extract the username from the user-id</p>
 		<div class="form form-inline">
 			<div class="form-group">
-				<input type="text" class="form-control" id="username3" placeholder="Github user id" onkeydown = "if (event.keyCode == 13) document.getElementById('get-infos-3').click()">
+				<input type="text" class="form-control" id="username3" placeholder="GitHub user id" onkeydown = "if (event.keyCode == 13) document.getElementById('get-infos-3').click()">
 			</div>
 
 			</br></br>


### PR DESCRIPTION
Just a minor typo fix: `Github` -> `GitHub`. Plus some whitespace fixes.